### PR TITLE
Remove callback being executed from error on syncDatasetClient

### DIFF
--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -190,8 +190,9 @@ function doClientSync(dataset_id, params, callback) {
             // Changes have been submitted from client, redo the list operation on back end system.
             DataSetModel.syncDatasetClient(datasetClient, function (err) {
               if (err) {
-                return callback(err);
+                syncUtil.doLog(dataset_id, 'warn', 'Failed to sync dataset client', params);
               }
+              syncUtil.doLog(dataset_id, 'info', 'Synced dataset client', params);
             });
           });
         }


### PR DESCRIPTION
Currently a callback is being invoked on syncDatasetClients callback
in `doClientSync`. This can result in an error where headers are being
appended to the response object after it has been sent.